### PR TITLE
更正ws协议地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ node app
 uin: 账号
 password: '密码'
 post-format: array
-universal: ws://localhost:2536/OneBotv11
+universal: ws://localhost:2536/go-cqhttp
 ```
 
 </details>
@@ -98,7 +98,7 @@ universal: ws://localhost:2536/OneBotv11
 下载安装 [LLOneBot](https://github.com/LLOneBot/LLOneBot)，启用反向 WebSocket，添加地址：
 
 ```
-ws://localhost:2536/OneBotv11
+ws://localhost:2536/go-cqhttp
 ```
 
 </details>


### PR DESCRIPTION
参照文档所述的OneBotV11协议，根据实践证明需要使用 `ws://localhost:2536/go-cqhttp` 才能正常建立ws连接并正常应用机器人
![图内内容](https://img2.imgtp.com/2024/03/03/aT5fvDxp.png)
