### PR TITLE
当stdin关闭时避免程序退出

### DIFF
--- a/lib/plugins/stdin.js
+++ b/lib/plugins/stdin.js
@@ -113,7 +113,7 @@ Bot.adapter.push(new class stdinAdapter {
         input: process.stdin,
         output: process.stderr,
       }).on("line", data => this.message(String(data)))
-        .on("close", () => process.exit(1)),
+        .on("close", () => Bot.makeLog("warn", "stdin disconnected")),
 
       uin: this.id,
       nickname: this.name,


### PR DESCRIPTION
在docker环境下，退出it模式，stdin会自动触发close事件，此时不应该整个程序异常退出