### PR TITLE
Update OneBotv11.js

### DIFF
--- a/plugins/adapter/OneBotv11.js
+++ b/plugins/adapter/OneBotv11.js
@@ -112,7 +112,7 @@ Bot.adapter.push(new class OneBotv11Adapter {
   sendGroupMsg(data, msg) {
     return this.sendMsg(msg, message => {
       Bot.makeLog("info", `发送群消息：${this.makeLog(message)}`, `${data.self_id} => ${data.group_id}`)
-      return data.bot.sendApi("send_msg", {
+      return data.bot.sendApi("send_group_msg", {
         group_id: data.group_id,
         message,
       })


### PR DESCRIPTION
修复(或许)napcat使用send_msg发送群聊消息时可能会出现报错：  message: 'Error: 请指定 group_id 或 user_id\n'