### PR TITLE
bug fix: 添加图片后，长时间再发显示图片过期

### DIFF
--- a/plugins/system/add.js
+++ b/plugins/system/add.js
@@ -142,7 +142,7 @@ export class add extends plugin {
     if (!this.e.msg?.includes("#结束添加")) {
       /** 添加内容 */
       for (const i of this.e.message) {
-        if (i.url) i.file = await this.saveFile(i)
+        if (i.url) { i.file = await this.saveFile(i); delete i.url; }
         if (i.type == "at" && i.qq == this.e.self_id) continue
         context.message.push(i)
       }


### PR DESCRIPTION
qq图床现在有限时，发图片的时候不能带url，否则显示过期。所以这里直接删掉url