### PR TITLE
fix: 启动参数丢失

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,8 +13,9 @@ switch (process.env.app_type || process.argv[2]) {
     process.exit()
   } default: {
     const { spawnSync } = await import("node:child_process")
+    const otherArgv = [...process.argv].splice(2)
     while (!spawnSync(process.argv[0],
-      [process.argv[1], "start"],
+      [process.argv[1], "start", ...otherArgv],
       { stdio: "inherit" },
     ).status) {}
     process.exit()


### PR DESCRIPTION
修复通过`npm run dev`启动的项目无法判断自身是否是在`dev`环境下

![image](https://github.com/user-attachments/assets/86709061-e5b4-4f1a-8006-0efc24013e97)