### PR TITLE
add avatar support for GSUIDCore

### DIFF
--- a/plugins/adapter/GSUIDCore.js
+++ b/plugins/adapter/GSUIDCore.js
@@ -159,6 +159,7 @@ Bot.adapter.push(new class GSUIDCoreAdapter {
       bot: Bot[id],
       group_id: group_id,
       user_id: user_id,
+      getAvatarUrl: () => i.avatar
     }
     return {
       ...this.pickFriend(id, user_id),
@@ -236,8 +237,7 @@ Bot.adapter.push(new class GSUIDCoreAdapter {
       this.makeBot(data, ws)
     }
 
-    if (!data.bot.fl.has(data.user_id))
-      data.bot.fl.set(data.user_id, data.sender)
+    data.bot.fl.set(data.user_id, data.sender)
 
     for (const i of raw.content) {
       switch (i.type) {
@@ -285,8 +285,7 @@ Bot.adapter.push(new class GSUIDCoreAdapter {
         gml = new Map
         data.bot.gml.set(data.group_id, gml)
       }
-      if (!gml.has(data.user_id))
-        gml.set(data.user_id, data.sender)
+      gml.set(data.user_id, data.sender)
 
       Bot.makeLog("info", `群消息：${data.raw_message}`, `${data.self_id} <= ${data.group_id}, ${data.user_id}`, true)
     }


### PR DESCRIPTION
用户的头像可以从sender里面获取：
https://docs.sayu-bot.com/CodeAdapter/Protocol.html#%E4%B8%8A%E6%8A%A5%E6%B6%88%E6%81%AF

<img width="843" alt="image" src="https://github.com/user-attachments/assets/bfe91fea-ebd0-4c31-aaf5-600fe230935c" />
