### PR TITLE
add msg_id property on sendApi data

### DIFF
--- a/plugins/adapter/GSUIDCore.js
+++ b/plugins/adapter/GSUIDCore.js
@@ -122,6 +122,7 @@ Bot.adapter.push(
         bot_self_id: data.bot.bot_self_id,
         target_type: "direct",
         target_id: data.user_id,
+        msg_id: data.message_id,
         content,
       })
       return { message_id: Date.now().toString(36) }
@@ -141,6 +142,7 @@ Bot.adapter.push(
         bot_self_id: data.bot.bot_self_id,
         target_type: target[0],
         target_id: target[1],
+        msg_id: data.message_id,
         content,
       })
       return { message_id: Date.now().toString(36) }


### PR DESCRIPTION
`msg_id` should send from the adapter as required by the spec: 
https://docs.sayu-bot.com/CodeAdapter/Protocol.html#%E5%8F%91%E9%80%81%E6%B6%88%E6%81%AF
<img width="804" height="460" alt="image" src="https://github.com/user-attachments/assets/3680ff67-c0e6-459d-b19b-6f2f2dc07251" />
