### PR TITLE
fix: sendFriendMsg/sendGroupMsg 在 bot 离线时误将 user_id 作为消息内容发送

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -466,7 +466,7 @@ export default class Yunzai extends EventEmitter {
       if (this.uin.includes(bot_id) && this.bots[bot_id])
         return this.bots[bot_id].pickFriend(user_id).sendMsg(...args)
 
-      if (this.pickFriend(bot_id, true)) return this.pickFriend(bot_id).sendMsg(user_id, ...args)
+      if (!args.length && this.pickFriend(bot_id, true)) return this.pickFriend(bot_id).sendMsg(user_id)
 
       const { promise, resolve, reject } = Promise.withResolvers()
       const listener = data => {
@@ -491,7 +491,7 @@ export default class Yunzai extends EventEmitter {
       if (this.uin.includes(bot_id) && this.bots[bot_id])
         return this.bots[bot_id].pickGroup(group_id).sendMsg(...args)
 
-      if (this.pickGroup(bot_id, true)) return this.pickGroup(bot_id).sendMsg(group_id, ...args)
+      if (!args.length && this.pickGroup(bot_id, true)) return this.pickGroup(bot_id).sendMsg(group_id)
 
       const { promise, resolve, reject } = Promise.withResolvers()
       const listener = data => {


### PR DESCRIPTION
## 问题

当 `sendMasterMsg` 触发（如 bot 离线、重启、更新通知）时，如果 `sendFriendMsg(bot_id, user_id, msg)` 中 `bot_id` 对应的 bot 不在线，fallback 逻辑会将 `bot_id` 视为好友、`user_id` 作为消息内容发送，导致主人 QQ 号被意外发送给其他用户。

### 复现步骤

1. 配置 `master: "A:B"`，A 为某 bot QQ
2. 用另一个 bot C 登录，A 保持离线
3. 触发 `sendMasterMsg`（如重启通知）
4. B（主人QQ号）被当作消息文本发送给 A

### 根因

`lib/bot.js` 中 `sendFriendMsg` 的 fallback 分支原本为两参数便捷调用设计：

```js
if (this.pickFriend(bot_id, true)) return this.pickFriend(bot_id).sendMsg(user_id, ...args)
```

当以三参数 `(bot_id, user_id, msg)` 调用且 bot_id 不在线时，`user_id` 被误当作消息内容，实际消息 `msg` 被丢弃。`sendGroupMsg` 同理。

## 修复

添加 `!args.length` 守卫，仅两参数便捷调用时走 fallback，三参数调用在 bot 离线时正确进入等待上线逻辑。