### PR TITLE
fix(adapter): 修复 OneBot v11 适配器全员禁言报错，增加戳一戳撤回事件支持

### DIFF
--- a/plugins/adapter/OneBotv11.js
+++ b/plugins/adapter/OneBotv11.js
@@ -1147,7 +1147,9 @@ Bot.adapter.push(
             `${data.self_id} <= ${data.group_id}`,
             true,
           )
-          data.bot.pickMember(data.group_id, data.user_id).getInfo()
+          if (data.user_id !== 0) {
+            data.bot.pickMember(data.group_id, data.user_id).getInfo()
+          }
           break
         case "group_msg_emoji_like":
           Bot.makeLog(
@@ -1181,6 +1183,23 @@ Bot.adapter.push(
                   `好友戳一戳：${data.operator_id} => ${data.target_id}`,
                   data.self_id,
                 )
+              break
+            case "poke_recall":
+              data.operator_id = data.user_id
+              if (data.group_id) {
+                Bot.makeLog(
+                  "info",
+                  `群戳一戳撤回：${data.operator_id} => ${data.target_id}`,
+                  `${data.self_id} <= ${data.group_id}`,
+                  true
+                )
+              } else {
+                Bot.makeLog(
+                  "info",
+                  `好友戳一戳撤回：${data.operator_id} => ${data.target_id}`,
+                  data.self_id,
+                )
+              }
               break
             case "honor":
               Bot.makeLog(


### PR DESCRIPTION
## 1.修复全员禁言时`user_id=0`导致获取用户信息失败
### 问题描述
当群聊开启或关闭全员禁言时，OneBot协议会将`user_id`设为`0`，表示作用于全体成员。原适配器在`notice`事件的`group_ban`分支中无条件调用`data.bot.pickMember(...).getInfo()`，尝试向OneBot API请求`user_id=0`的用户信息，导致返回`retcode 1200`并抛出“无法获取用户信息”的错误

### 解决方案
在`makeNotice`函数的`case "group_ban":`分支中增加判断：仅当`user_id !== 0`时才调用`getInfo()`

## 2.适配戳一戳撤回事件`poke_recall`
### 问题描述
OneBot协议定义了`notify`事件的`sub_type`为`poke_recall`，表示用户撤回了一次戳一戳。原适配器未处理该子类型，导致控制台输出“未知通知”警告。

### 解决方案
在`makeNotice`函数的`case "notify":`的`switch(data.sub_type)`中添加`case "poke_recall": `分支。