### PR TITLE
fix(loader): 修复群功能黑白名单误影响私聊的问题

### DIFF
--- a/lib/plugins/loader.js
+++ b/lib/plugins/loader.js
@@ -630,6 +630,8 @@ class PluginsLoader {
 
   /** 判断是否启用功能 */
   checkDisable(p) {
+    // 私信不应受到默认群配置的影响
+    if (!p.e.isGroup) return true
     const groupCfg = cfg.getGroup(p.e.self_id, p.e.group_id)
     if (groupCfg.disable?.length && groupCfg.disable.includes(p.name)) return false
     if (groupCfg.enable?.length && !groupCfg.enable.includes(p.name)) return false


### PR DESCRIPTION
## 问题描述
在群聊配置（config/group）中，默认群配置的黑白名单功能会错误影响私信使用。

## 复现步骤
1. 在`config/group.yaml`的`default`下禁用某个`功能A`；
2. 用自己的主人QQ在私聊中发送`功能A `的命令；
3. 观察到`功能A `被错误地拦截。

## 预期行为
私聊不应受到群聊配置的影响，功能应正常执行。

## 解决方案
私聊消息不应受到群聊配置的限制，现增加私聊判断，确保群聊配置仅对群聊生效。

## 额外建议
可加入类似群配置的私聊配置，控制默认情况下的私聊功能（同时，确保主人和白名单用户不受限制）