### PR TITLE
feat(adapter): 为 OneBot v11 适配器添加私聊文件直链获取方法

### DIFF
--- a/plugins/adapter/OneBotv11.js
+++ b/plugins/adapter/OneBotv11.js
@@ -674,6 +674,13 @@ Bot.adapter.push(
         busid,
       })
     }
+    // 获取私聊文件URL
+    getPrivateFileUrl(data, file_id) {
+      return data.bot.sendApi("get_private_file_url", { 
+        user_id: data.user_id, 
+        file_id 
+      });
+    }
 
     getGroupFs(data) {
       return {
@@ -747,6 +754,7 @@ Bot.adapter.push(
         getChatHistory: this.getFriendMsgHistory.bind(this, i),
         thumbUp: this.sendLike.bind(this, i),
         delete: this.deleteFriend.bind(this, i),
+        getFileUrl: this.getPrivateFileUrl.bind(this, i),
       }
     }
 


### PR DESCRIPTION
## 背景
当前`OneBot v11`适配器已支持获取群文件下载直链（`getGroupFileUrl`），但缺少对应的私聊文件直链接口。在`LLOneBot`、`NapCat`等实现中，私聊文件消息可通过`get_private_file_url`协议API获取真实下载地址。若适配器不提供封装，插件开发者只能使用通用的`Bot.sendApi`调用，与适配器现有风格不一致。

## 改动说明
1. 新增`getPrivateFileUrl`方法
在`OneBotv11Adapter`类中添加方法：
```JavaScript
getPrivateFileUrl(data, file_id) {
  return data.bot.sendApi("get_private_file_url", { 
    user_id: data.user_id, 
    file_id 
  });
}
```
该方法遵循现有`getGroupFileUrl`的设计，直接调用协议端接口并返回原始响应（已由适配器的`Proxy`自动解包）。

2. 在`pickFriend`中暴露调用入口
在`pickFriend`返回对象中添加`getFileUrl`方法:
```JavaScript
pickFriend(data, user_id) {
    const i = { ...data.bot.fl.get(user_id), ...data, user_id };
    return {
        ...i,
        // ... 已有方法
        getFileUrl: this.getPrivateFileUrl.bind(this, i),
    };
}
```
插件可通过`Bot.pickFriend(user_id).getFileUrl(file_id)`获取直链。

## 插件端调用方法
插件端可通过好友对象调用方法获取文件直链：
```JavaScript
const friend = Bot.pickFriend(user_id);
const result = await friend.getFileUrl(file_id);
const url = result?.url;  // 直链地址
if (url) {
    const response = await fetch(url);
    // 处理文件流...
}
```
其中：`get_private_file_url`返回值中`url`字段位于顶层（而非嵌套在`data`中），适配器已将其代理到返回对象顶层，插件可直接访问`result.url`。

该改动要求底层`OneBot`实现支持`get_private_file_url`动作（LLOneBot、go-cqhttp与NapCat较新版本均已支持）。对于不支持的协议端，调用时会正常抛出异常，插件需自行捕获。

## 测试
该适配已经在`TRSS-Yunzai`+`LLOneBot`的环境下测试通过，示例插件代码：
```JavaScript
const userId = e.user_id;
let fileUrl;
const user = Bot.pickFriend(userId);
if (typeof user.getFileUrl === 'function') {
  // 如果提供了封装方法
  const res = await user.getFileUrl(fileId);
  fileUrl = res?.url;
} else {
  // 降级到通用 sendApi
  const res = await Bot.sendApi('get_private_file_url', { user_id: userId, file_id: fileId });
  fileUrl = res?.data?.url;
}
if (fileUrl && (fileUrl.startsWith('http://') || fileUrl.startsWith('https://'))) {
  const response = await fetch(fileUrl);
  if (response.ok) {
     logger.mark(`[课表管理] 私聊文件HTTP下载成功`)
     return await response.text();
  }
  logger.warn(`[课表管理] 私聊文件下载失败，状态码: ${response.status}`);
}
```
经测试，在私聊发送文件，能够成功进入`user.getFileUrl`分支，并获取直链下载用户文件。
