### PR TITLE
feat(adapter): 为OneBot v11适配器新增群公告发送与获取方法

### DIFF
--- a/plugins/adapter/OneBotv11.js
+++ b/plugins/adapter/OneBotv11.js
@@ -594,6 +594,42 @@ Bot.adapter.push(
       })
     }
 
+    async sendGroupNotice(
+      data,
+      content,
+      image,
+      pinned = false,
+      confirm_required = true,
+      is_show_edit_card = false,
+      tip_window = false,
+      send_new_member = false,
+    ) {
+      Bot.makeLog(
+        "info",
+        `发送群公告：${content}`,
+        `${data.self_id} => ${data.group_id}`,
+        true,
+      )
+      if (image) image = await this.makeFile(image)
+      return data.bot.sendApi("_send_group_notice", {
+        group_id: data.group_id,
+        content,
+        image,
+        pinned,
+        confirm_required,
+        is_show_edit_card,
+        tip_window,
+        send_new_member,
+      })
+    }
+
+    getGroupNotice(data) {
+      Bot.makeLog("info", "获取群公告", `${data.self_id} => ${data.group_id}`, true)
+      return data.bot.sendApi("_get_group_notice", {
+        group_id: data.group_id,
+      })
+    }
+
     downloadFile(data, url, thread_count, headers) {
       return data.bot.sendApi("download_file", {
         url,
@@ -869,6 +905,8 @@ Bot.adapter.push(
         muteAll: this.setGroupWholeKick.bind(this, i),
         kickMember: this.setGroupKick.bind(this, i),
         quit: this.setGroupLeave.bind(this, i),
+        sendNotice: this.sendGroupNotice.bind(this, i),
+        getNotice: this.getGroupNotice.bind(this, i),
         fs: this.getGroupFs(i),
         get is_owner() {
           return data.bot.gml.get(group_id)?.get(data.self_id)?.role === "owner"


### PR DESCRIPTION
为`OneBotv11 Adapter `补全群公告相关API的封装，使插件/机器人能够通过统一的`pickGroup`对象便捷地发送和获取群公告。

## 改动内容
新增方法（位于`OneBotv11Adapter`类）：

`async sendGroupNotice(data, content, image, pinned, confirm_required, is_show_edit_card, tip_window, send_new_member)`
→ 调用`OneBot`扩展接口`_send_group_notice`
→ 支持`content`必填，`image`可选（自动处理`http://`、`file://`、`base64://`格式）
→ 其余可选参数均使用与OneBot标准一致的默认值（`pinned=false`, `confirm_required=true`, `is_show_edit_card=false`, `tip_window=false`, `send_new_member=false`）
→ 异步，内部记录日志

`getGroupNotice(data)`
→ 调用`OneBot`接口`_get_group_notice`
→ 仅需`group_id`，返回公告列表

在`pickGroup`中为群对象绑定`sendNotice`和`getNotice`方法，便于直接调用。

## 使用示例
```JS
// 获取群对象
const group = Bot.pickGroup(e.group_id);

// 发送普通公告
await group.sendNotice('今日起开放时间调整为 8:00-22:00');

// 发送带图片公告（图片支持 URL / 本地路径 / base64）
await group.sendNotice('新活动上线', 'https://example.com/poster.png');

// 发送置顶公告
await group.sendNotice('紧急通知', null, true);

// 获取群公告列表
const notices = await group.getNotice();
logger.info(notices); // 数组，每项含 title, content,等字段
```

## 补充信息
两个API均属于`OneBot`扩展接口，需要协议端支持该能力。该接口已在LLBot和NapCat等主流协议端测试通过，可直接使用。
参考文档：
- [LLBot](https://s.apifox.cn/a7b7a53c-8b85-4885-8573-103cfffb75ac/api-227239056)
- [Lagrange.OneBot](https://lagrange-onebot.apifox.cn/236980823e0)