### PR TITLE
fix(adapter): OneBotv11 对 send_msg 中的 file 段防御性路由到专用上传 API

### DIFF
--- a/plugins/adapter/OneBotv11.js
+++ b/plugins/adapter/OneBotv11.js
@@ -56,6 +56,7 @@ Bot.adapter.push(
       if (!Array.isArray(msg)) msg = [msg]
       const msgs = []
       const forward = []
+      const files = []
       for (let i of msg) {
         if (typeof i !== "object") i = { type: "text", data: { text: i } }
         else if (!i.data) i = { type: i.type, data: { ...i, type: undefined } }
@@ -72,26 +73,35 @@ Bot.adapter.push(
           case "node":
             forward.push(...i.data)
             continue
+          case "file":
+            files.push({ file: i.data.file, name: i.data.name })
+            continue
           case "raw":
             i = i.data
             break
         }
 
-        if (i.data.file) i.data.file = await this.makeFile(i.data.file)
+        if (i.data?.file) i.data.file = await this.makeFile(i.data.file)
 
         msgs.push(i)
       }
-      return [msgs, forward]
+      return [msgs, forward, files]
     }
 
-    async sendMsg(msg, send, sendForwardMsg) {
-      const [message, forward] = await this.makeMsg(msg)
+    async sendMsg(msg, send, sendForwardMsg, sendFile) {
+      const [message, forward, files] = await this.makeMsg(msg)
       const ret = []
 
       if (forward.length) {
         const data = await sendForwardMsg(forward)
         if (Array.isArray(data)) ret.push(...data)
         else ret.push(data)
+      }
+      
+      for (const { file, name } of files) {
+        if (sendFile) {
+          ret.push(await sendFile(file, name || path.basename(file)))
+        }
       }
 
       if (message.length) ret.push(await send(message))
@@ -118,6 +128,7 @@ Bot.adapter.push(
           })
         },
         msg => this.sendFriendForwardMsg(data, msg),
+        (file, name) => this.sendFriendFile(data, file, name),
       )
     }
 
@@ -137,6 +148,7 @@ Bot.adapter.push(
           })
         },
         msg => this.sendGroupForwardMsg(data, msg),
+        (file, name) => this.sendGroupFile(data, file, undefined, name),
       )
     }
 


### PR DESCRIPTION
 ### 背景

  部分 OneBot 协议实现（如 LLOneBot 新版本(如`v8.0.1`)）不再对 `send_msg` 中的 `type: "file"` 消息段自动路由到文件上传
  API，导致插件通过 `e.reply(segment.file(...))` 发送文件时报错：

  ```
  Error: 消息体无法解析，请检查是否发送了不支持的消息类型 (retcode: 1200)
  ```

  **根本原因**：当前 `makeMsg` 对所有消息段一视同仁，`type: "file"` 段未做特殊处理，直接被拼入 `send_msg`
  的消息数组中。而适配器中早已存在 `sendGroupFile`（调用 `upload_group_file`）和 `sendFriendFile`（调用
  `upload_private_file`）的实现，只是消息管道从未将文件段路由到这些专用 API。

  ### 变更内容

  在 `plugins/adapter/OneBotv11.js` 中修改 4 个方法：

  | 方法 | 改动 |
  |------|------|
  | `makeMsg` | 新增 `case "file"` 分支，将文件段提取到独立的 `files` 数组（类似 `case "node"`
  提取转发节点），返回值从二元组扩展为三元组 |
  | `sendMsg` | 新增可选第 4 参数 `sendFile`，解构 `files` 数组，遍历调用文件上传回调 |
  | `sendGroupMsg` | 传入 `sendFile` 回调 → `sendGroupFile` |
  | `sendFriendMsg` | 传入 `sendFile` 回调 → `sendFriendFile` |
  | `sendGuildMsg` | 不修改（无对应频道文件上传 API，文件段静默丢弃） |

  ### 关键设计决策

  1. **文件段不经过 `makeFile()` 编码**：`case "file"` 用 `continue` 跳过 `makeFile`（base64 编码）和 `msgs.push`，保留原始文件路径给专用上传 API 处理
  2. **自动拆分混发消息**：QQ 不允许文件与文本在同一消息中混发。当 `segment.file(...)` 与文本一起传入时，文件段自动剥离走专用 API，剩余文本正常走 `send_msg`
  3. **向后兼容**：`makeMsg` 返回三元组，现有 `const [a, b] = ...` 二元解构自动忽略第三项；`sendMsg` 第 4 参数可选，不传行为等同旧版

  ### 边界情况处理

  | 场景 | 行为 |
  |------|------|
  | 纯文件消息 | 只调`upload`API，不调`send_msg` |
  | 文件 + 文本/图片混发 | 自动拆分：文件走`upload`API，其余走`send_msg` |
  | 多文件 | 逐个调`upload`API |
  | 纯文本/图片/at 等 | 完全不变（`files` 数组为空） |
  | 频道消息含文件 | 静默丢弃 |
  | 其他适配器 | 不受影响（仅改`OneBotv11.js`） |

  ### 影响范围

  - **仅影响 OneBotv11 适配器**，不触及任何插件代码
  - 对 NapCat 等已做自动路由的协议端无回归（文件在 `send_msg` 前已被提取，消息体中不再含 `type: "file"` 段）
  - 所有通过 `e.reply(segment.file(...))` 的插件调用均受益

  ### 验证

  - [x] LLOneBot 新版本群聊发送文件正常
  - [x] 纯文本消息无回归
  - [x] 图片消息无回归
  - [x] 私聊文件发送正常
  - [x] 文件 + 文本混发拆分正常